### PR TITLE
batches: Add support for deleted lines

### DIFF
--- a/internal/diff/unified.go
+++ b/internal/diff/unified.go
@@ -182,17 +182,8 @@ func (u Unified) Format(f fmt.State, r rune) {
 			}
 		}
 		fmt.Fprint(f, "@@")
-		fmt.Println(fromCount, toCount, "<===", hunk.ToLine)
-		if fromCount > 1 {
-			fmt.Fprintf(f, " -%d,%d", hunk.FromLine, fromCount)
-		} else {
-			fmt.Fprintf(f, " -%d,%d", fromCount, fromCount)
-		}
-		if toCount > 1 {
-			fmt.Fprintf(f, " +%d,%d", hunk.ToLine, toCount)
-		} else {
-			fmt.Fprintf(f, " +%d,%d", toCount, toCount)
-		}
+		fmt.Fprintf(f, " -%d,%d", fromCount, fromCount)
+		fmt.Fprintf(f, " +%d,%d", hunk.ToLine, toCount)
 		fmt.Fprint(f, " @@\n")
 		for _, l := range hunk.Lines {
 			switch l.Kind {

--- a/internal/diff/unified.go
+++ b/internal/diff/unified.go
@@ -182,15 +182,16 @@ func (u Unified) Format(f fmt.State, r rune) {
 			}
 		}
 		fmt.Fprint(f, "@@")
+		fmt.Println(fromCount, toCount, "<===", hunk.ToLine)
 		if fromCount > 1 {
 			fmt.Fprintf(f, " -%d,%d", hunk.FromLine, fromCount)
 		} else {
-			fmt.Fprintf(f, " -%d", hunk.FromLine)
+			fmt.Fprintf(f, " -%d,%d", fromCount, fromCount)
 		}
 		if toCount > 1 {
 			fmt.Fprintf(f, " +%d,%d", hunk.ToLine, toCount)
 		} else {
-			fmt.Fprintf(f, " +%d", hunk.ToLine)
+			fmt.Fprintf(f, " +%d,%d", toCount, toCount)
 		}
 		fmt.Fprint(f, " @@\n")
 		for _, l := range hunk.Lines {

--- a/internal/diff/unified.go
+++ b/internal/diff/unified.go
@@ -182,8 +182,13 @@ func (u Unified) Format(f fmt.State, r rune) {
 			}
 		}
 		fmt.Fprint(f, "@@")
-		fmt.Fprintf(f, " -%d,%d", fromCount, fromCount)
-		fmt.Fprintf(f, " +%d,%d", hunk.ToLine, toCount)
+		if fromCount == 0 {
+			fmt.Fprintf(f, " -0,0 +%d,%d", hunk.ToLine, toCount)
+		} else if toCount == 0 {
+			fmt.Fprintf(f, " -%d,%d +0,0", hunk.FromLine, fromCount)
+		} else {
+			fmt.Fprintf(f, " -%d,%d +%d,%d", hunk.FromLine, fromCount, hunk.ToLine, toCount)
+		}
 		fmt.Fprint(f, " @@\n")
 		for _, l := range hunk.Lines {
 			switch l.Kind {

--- a/main_test.go
+++ b/main_test.go
@@ -2,4 +2,6 @@ package godiffpatch
 
 import "testing"
 
-func TestGeneratePatch(t *testing.T) {}
+func TestGeneratePatch(t *testing.T) {
+
+}


### PR DESCRIPTION
When generating a patch for a file in which all of its content is deleted, the [hunk](https://www.gnu.org/software/diffutils/manual/html_node/Hunks.html) headers generated look like

```
--- a/.gitignore
+++ b/.gitignore
@@ -1,42 +1 @@
```

which makes it not `git-compatible`.  The correct header should look like:

```
--- a/.gitignore
+++ b/.gitignore
@@ -1,42 +1,0 @@
```

The hunk is always in the format `xx,xx` when I run `git diff`, I'm not sure why that condition was added but it corrupts the patch when all lines are deleted in a file.